### PR TITLE
Login component rendered after login on homepage #401 - avoid setting intendedRoute to 'login'

### DIFF
--- a/src/errorHandler.js
+++ b/src/errorHandler.js
@@ -31,7 +31,9 @@ const getUserFeedback = vm => axios.get('api/sentry')
         : toastError(vm)));
 
 const redirectToLogin = vm => {
-    vm.$store.commit('auth/setIntendedRoute', vm.$route);
+    if (vm.$route.name !== 'login') {
+        vm.$store.commit('auth/setIntendedRoute', vm.$route);
+    }
     vm.$store.commit('appState', false);
     vm.$store.commit('auth/logout');
     vm.$router.push({ name: 'login' })


### PR DESCRIPTION
- fix for solution 2. described in #401 - avoid setting `intendedRoute` to 'login'. @aconeanu mentioned :"We never want the intended route to be login.". Issue occurred when a link was clicked while the app session was expired, and `intendedRoute` was overwriting initial intended route with additional API calls (like loading some filter options) which were redirected to login. This made the next page after login load a login form as homepage.
- related to https://github.com/laravel-enso/enso/issues/401
- related to https://github.com/enso-ui/auth/pull/5
- related to https://github.com/enso-ui/auth/pull/6